### PR TITLE
fixed keybindings due to depreciation of .editor class

### DIFF
--- a/keymaps/auto-indent.cson
+++ b/keymaps/auto-indent.cson
@@ -7,8 +7,8 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.platform-darwin .editor':
+'.platform-darwin atom-text-editor':
   'cmd-shift-i': 'auto-indent:apply'
 
-'.platform-win32 .editor, .platform-linux .editor':
+'.platform-win32 atom-text-editor, .platform-linux atom-text-editor':
   'ctrl-shift-i': 'auto-indent:apply'


### PR DESCRIPTION
.editor class is depreciated, replaced by atom-text-editor. Tested in win32 and Linux, Darwin should be same result.